### PR TITLE
Fix duplo/install on cimg/base:2026.x (PEP 668)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -32,7 +32,7 @@ jobs:
     - duplo/setup:
         cloud: aws
         admin: true
-        tenant: toolstest
+        tenant: duplo-tools
     - run: aws sts get-caller-identity
   # Regression test for DUPLO-42822: duplo/install must work on the cimg/base 2026.x
   # line, which moved to Ubuntu 24.04 and enforces PEP 668.
@@ -53,21 +53,21 @@ workflows:
     # Test your orb's commands in a custom job and test your orb's jobs directly as a part of this workflow.
     - duplo/update_services:
         filters: *filters
-        context: qa-aws
-        tenant: toolstest
+        context: test24
+        tenant: duplo-tools
         services: |-
           [
             { "Name": "nginx", "Image": "nginx:latest" }
           ]
     - duplo/update_image:
         filters: *filters
-        context: qa-aws
-        tenant: toolstest
+        context: test24
+        tenant: duplo-tools
         service: nginx
         image: nginx:latest
     - orb_tests:
         filters: *filters
-        context: qa-aws
+        context: test24
         requires:
         - duplo/update_image
         - duplo/update_services

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -30,10 +30,22 @@ jobs:
     # Run your orb's commands to validate them.
     - duplo/install
     - duplo/setup:
-        cloud: aws 
+        cloud: aws
         admin: true
         tenant: toolstest
     - run: aws sts get-caller-identity
+  # Regression test for DUPLO-42822: duplo/install must work on the cimg/base 2026.x
+  # line, which moved to Ubuntu 24.04 and enforces PEP 668.
+  install_smoke_cimg_base_2026:
+    docker:
+    - image: cimg/base:2026.02
+    steps:
+    - duplo/install
+    - run:
+        name: Verify duploctl is on PATH
+        command: |
+          command -v duploctl
+          duploctl --help >/dev/null
 workflows:
   test-deploy:
     jobs:
@@ -59,10 +71,13 @@ workflows:
         requires:
         - duplo/update_image
         - duplo/update_services
+    - install_smoke_cimg_base_2026:
+        filters: *filters
     # The orb must be re-packed for publishing, and saved to the workspace.
     - orb-tools/pack:
         requires:
         - orb_tests
+        - install_smoke_cimg_base_2026
         filters: *release-filters
     - orb-tools/publish:
         filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -24,7 +24,7 @@ jobs:
   # You may want to add additional validation steps to ensure the commands are working as expected.
   orb_tests:
     docker:
-    - image: cimg/aws:2024.03
+    - image: cimg/aws:2026.04
     steps:
     - checkout
     # Run your orb's commands to validate them.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+All notable changes to this project will be documented in this file. 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - aws jit step
  - a base and aws executor image preinstalled with duploctl
- - fix `duplo/install` on PEP 668 systems (Ubuntu 24.04 / cimg/base:2026.x): install via `pipx` instead of system `pip`. Also fixes apt array-quoting and missing `-y` (DUPLO-42822) .
+ - fix `duplo/install` on PEP 668 systems (Ubuntu 24.04 / cimg/base:2026.x): install via `pipx` instead of system `pip`. Also fixes apt array-quoting and missing `-y` (DUPLO-42822).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - aws jit step
  - a base and aws executor image preinstalled with duploctl
+ - fix `duplo/install` on PEP 668 systems (Ubuntu 24.04 / cimg/base:2026.x): install via `pipx` instead of system `pip`. Also fixes apt array-quoting and missing `-y` (DUPLO-42822).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,4 +9,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  - aws jit step
  - a base and aws executor image preinstalled with duploctl
- - fix `duplo/install` on PEP 668 systems (Ubuntu 24.04 / cimg/base:2026.x): install via `pipx` instead of system `pip`. Also fixes apt array-quoting and missing `-y` (DUPLO-42822).
+ - fix `duplo/install` on PEP 668 systems (Ubuntu 24.04 / cimg/base:2026.x): install via `pipx` instead of system `pip`. Also fixes apt array-quoting and missing `-y` (DUPLO-42822) .

--- a/src/scripts/duploctl_install.sh
+++ b/src/scripts/duploctl_install.sh
@@ -1,45 +1,82 @@
 #!/usr/bin/env bash
+# Installs duploctl. Uses pipx so we work on PEP 668-locked Pythons
+# (Ubuntu 24.04 / cimg/base:2026.x and beyond).
 
 PARAM_VERSION=$(circleci env subst "${PARAM_VERSION}")
 
-packagesNeeded=()
-
-# check if python is installed
-if ! command -v python &> /dev/null
-then
-    echo "Python could not be found"
-    packagesNeeded+=("python3")
+# Short-circuit if duploctl is already on PATH (e.g. the duplocloud/cimg-base executor
+# bakes it in at image build time).
+if command -v duploctl &>/dev/null; then
+  echo "duploctl already installed"
+  duploctl version -o yaml
+  exit 0
 fi
 
-# if pip is not installed
-if ! command -v pip &> /dev/null
-then
-    echo "Pip could not be found"
-    packagesNeeded+=("python3-pip")
+needs() { ! command -v "$1" &>/dev/null; }
+
+if   [ -x "$(command -v apt-get)" ]; then PM=apt
+elif [ -x "$(command -v apk)" ];     then PM=apk
+elif [ -x "$(command -v dnf)" ];     then PM=dnf
+elif [ -x "$(command -v zypper)" ];  then PM=zypper
+else                                      PM=
 fi
 
-# if jq is not installed
-if ! command -v jq &> /dev/null
-then
-    echo "jq could not be found"
-    packagesNeeded+=("jq")
+pkg_install() {
+  [ "$#" -eq 0 ] && return 0
+  case "$PM" in
+    apt)    sudo apt-get update && sudo apt-get install -y "$@" ;;
+    apk)    sudo apk add --no-cache "$@" ;;
+    dnf)    sudo dnf install -y "$@" ;;
+    zypper) sudo zypper install -y "$@" ;;
+    *)      echo "FAILED: no supported package manager found. Install manually: $*" >&2; return 1 ;;
+  esac
+}
+
+# Map a generic dependency name to the manager's package name.
+pkg_for() {
+  case "$1:$PM" in
+    python3:*)                  echo python3 ;;
+    pip:apk)                    echo py3-pip ;;
+    pip:apt|pip:dnf|pip:zypper) echo python3-pip ;;
+    pipx:apt|pipx:dnf)          echo pipx ;;
+    pipx:apk)                   echo py3-pipx ;;
+    pipx:zypper)                echo python3-pipx ;;
+    jq:*)                       echo jq ;;
+  esac
+}
+
+add_pkg() {
+  local p
+  p="$(pkg_for "$1")"
+  [ -n "$p" ] && packages+=("$p")
+}
+
+packages=()
+needs python3 && add_pkg python3
+needs jq      && add_pkg jq
+needs pipx    && add_pkg pipx
+
+pkg_install "${packages[@]}"
+
+# Fallback: bootstrap pipx via pip if the package manager didn't provide it
+# (older Alpine, minimal RHEL, etc.). --break-system-packages is the documented
+# escape hatch on PEP 668 systems and is safe in ephemeral CI containers.
+if ! command -v pipx &>/dev/null; then
+  needs pip3 && pkg_install "$(pkg_for pip)"
+  python3 -m pip install --user pipx 2>/dev/null \
+    || python3 -m pip install --user --break-system-packages pipx
 fi
 
-if [ -x "$(command -v apk)" ];       then sudo apk add --no-cache "${packagesNeeded[*]}"
-elif [ -x "$(command -v apt-get)" ]; then sudo apt update && sudo apt-get install "${packagesNeeded[*]}"
-elif [ -x "$(command -v dnf)" ];     then sudo dnf install "${packagesNeeded[*]}"
-elif [ -x "$(command -v zypper)" ];  then sudo zypper install "${packagesNeeded[*]}"
-else echo "FAILED TO INSTALL PACKAGE: Package manager not found. You must manually install: ${packagesNeeded[*]}">&2; fi
+# pipx drops binaries in ~/.local/bin; make sure subsequent steps see them.
+PIPX_BIN="${HOME}/.local/bin"
+export PATH="${PIPX_BIN}:${PATH}"
+echo "export PATH=\"${PIPX_BIN}:\$PATH\"" >> "$BASH_ENV"
 
-if ! command -v duploctl &> /dev/null
-then
-    if [[ "$PARAM_VERSION" == "latest" ]]; then
-        pip install duplocloud-client
-    else
-        pip install "duplocloud-client==$PARAM_VERSION"
-    fi
-    echo "Successfully installed duploctl"
+if [[ "$PARAM_VERSION" == "latest" ]]; then
+  pipx install duplocloud-client
+else
+  pipx install "duplocloud-client==$PARAM_VERSION"
 fi
 
-echo "Current Duplocloud versions:"
+echo "Successfully installed duploctl"
 duploctl version -o yaml


### PR DESCRIPTION
## PR Type

- [x] Bugfix
- [x] CI related changes

## What is the current behavior?

`duplo/install` fails on `cimg/base:2026.02` (Ubuntu 24.04). PEP 668 marks the system Python externally-managed, so `pip install duplocloud-client` aborts with `error: externally-managed-environment`.

Adjacent bugs in `duploctl_install.sh`:
- `"${packagesNeeded[*]}"` joins the array into one literal package name.
- `apt-get install` was missing `-y`.
- The script checks for `pip`, but cimg only ships `pip3`.

Issue Number: DUPLO-42822

## What is the new behavior?

- Install via `pipx` (isolated venv, sidesteps PEP 668).
- Correct per-distro pipx names: `pipx` (apt/dnf), `py3-pipx` (apk), `python3-pipx` (zypper). Pip-bootstrap fallback for images without pipx.
- Append `~/.local/bin` to `$BASH_ENV` so later steps see `duploctl`.
- Short-circuit when `duploctl` is already on PATH (prebuilt `duplocloud/cimg-base` executor).
- Apt invocation: `"${arr[@]}"`, `-y`, single PM detection upfront.
- New smoke test `install_smoke_cimg_base_2026` gates `orb-tools/pack`.

## Does this PR introduce a breaking change?
- [x] No

## Other information

CI validation comes from the new smoke job.